### PR TITLE
version 0.2.9 

### DIFF
--- a/lib/grenache/base.rb
+++ b/lib/grenache/base.rb
@@ -4,7 +4,7 @@ module Grenache
 
     # Initialize can accept custom configuration parameters
     def initialize(params = {})
-      @configuration = Configuration.new(params)
+      @configuration = Configuration.new(params) unless params.empty?
     end
 
     # Lookup for a specific service `key`

--- a/lib/grenache/base.rb
+++ b/lib/grenache/base.rb
@@ -47,7 +47,7 @@ module Grenache
     end
 
     def link
-      @link ||= Link.new(self.class.config)
+      @link ||= Link.new config
     end
   end
 end

--- a/lib/grenache/configurable.rb
+++ b/lib/grenache/configurable.rb
@@ -56,7 +56,7 @@ module Grenache
     end
 
     def config
-      self.class.config
+      @configuration || self.class.config
     end
 
     module ClassMethods

--- a/lib/grenache/configurable.rb
+++ b/lib/grenache/configurable.rb
@@ -14,7 +14,7 @@ module Grenache
 
     # Initialize default values
     def initialize(params = {})
-      set_val :grape_address, params, "ws://127.0.0.1:30001"
+      set_val :grape_address, params, "http://127.0.0.1:40001/"
       set_val :timeout, params, 5
 
       set_val :auto_announce_interval, params, 5
@@ -41,6 +41,7 @@ module Grenache
 
     def set_val(name, params, default)
       method = "#{name}=".to_sym
+
       if params[name]
         send(method, params[name])
       else

--- a/lib/grenache/version.rb
+++ b/lib/grenache/version.rb
@@ -1,3 +1,3 @@
 module Grenache
-  VERSION = '0.2.7'
+  VERSION = '0.2.9'
 end

--- a/spec/grenache/base_spec.rb
+++ b/spec/grenache/base_spec.rb
@@ -19,6 +19,10 @@ describe Grenache::VERSION do
     end
 
     it { expect(Grenache::Base.config.timeout).to eq(10) }
+
+    it { expect(Grenache::Base.new( timeout: 11).config.timeout).to eq(11) }
   end
+
+
 end
 


### PR DESCRIPTION
BUGFIXES:
- ignore instance configuration when not provided
- `link` to use instance configuration when provided
- grape ws is discontinued