### PR TITLE
Fix defaults

### DIFF
--- a/lib/grenache/configurable.rb
+++ b/lib/grenache/configurable.rb
@@ -50,18 +50,15 @@ module Grenache
     end
 
     module ClassMethods
-      def configure
-        yield config
-      end
-
       # Class configuration
       def config
-        @configuration ||= Configuration.new
+        Grenache::Configuration.default
       end
 
       def default_conf &block
         Grenache::Configuration.set_default &block
       end
+      alias_method :configure, :default_conf
     end
   end
 end

--- a/lib/grenache/configurable.rb
+++ b/lib/grenache/configurable.rb
@@ -16,7 +16,7 @@ module Grenache
   class Configuration < BaseConfiguration
 
     def initialize(params = {})
-      @values = self.class.default.values
+      @values = self.class.default.values.clone
 
       params.each do |k, v|
         @values[k.to_s] = v

--- a/lib/grenache/version.rb
+++ b/lib/grenache/version.rb
@@ -1,3 +1,3 @@
 module Grenache
-  VERSION = '0.2.17'
+  VERSION = '0.2.18'
 end


### PR DESCRIPTION
1. Clone defaults so we don't modify them (functionally the same change that was reverted, just using clone).    This does stop new instances from changing defaults.
2. Combine Grenache::Base.configuration with Configuration.defaults.   This is so `Grenache::Http.configure do |conf|` changes the defaults.