### PR TITLE
bump httparty

### DIFF
--- a/grenache-ruby-base.gemspec
+++ b/grenache-ruby-base.gemspec
@@ -16,10 +16,12 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version     = '>= 2.7.0'
+
   spec.add_runtime_dependency "eventmachine", "~> 1.2"
   spec.add_runtime_dependency "faye-websocket", "~> 0.10"
   spec.add_runtime_dependency "oj", "~> 3.6"
-  spec.add_runtime_dependency "httparty", "~> 0.16"
+  spec.add_runtime_dependency "httparty", "~> 0.22.0"
 
   spec.add_development_dependency "rspec", "~> 3.5"
 end

--- a/grenache-ruby-base.gemspec
+++ b/grenache-ruby-base.gemspec
@@ -16,8 +16,6 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version     = '>= 2.7.0'
-
   spec.add_runtime_dependency "eventmachine", "~> 1.2"
   spec.add_runtime_dependency "faye-websocket", "~> 0.10"
   spec.add_runtime_dependency "oj", "~> 3.6"

--- a/lib/grenache/version.rb
+++ b/lib/grenache/version.rb
@@ -1,3 +1,3 @@
 module Grenache
-  VERSION = '0.2.18'
+  VERSION = '0.2.19'
 end


### PR DESCRIPTION
 - bumped httparty:

Name: httparty
Version: 0.18.1
CVE: CVE-2024-22049
GHSA: GHSA-5pq7-52mg-hr42
Criticality: Medium
URL: https://github.com/jnunemaker/httparty/security/advisories/GHSA-5pq7-52mg-hr42
Title: httparty has multipart/form-data request tampering vulnerability
Solution: upgrade to '>= 0.21.0'

Vulnerabilities found!